### PR TITLE
shorter for --preserve-git

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The CLI is pretty self-explanatory:
 git get [-v|--verbose|-q|--quiet]
     <url> | <user>/<repo> [<branch>|<sha1>]
     [-o <target> | --output=<target>] [-f|--force] [-F|--rm-rf]
-    [--preserve-git | [-t [--tag-file=VERSION]] [-- <path>]]
+    [-g|--preserve-git | [-t [--tag-file=VERSION]] [-- <path>]]
 
 git gets [-v|--verbose|-q|--quiet] [--no-recursive]
     <url> | <user>/<repo> [<branch>|<sha1>]
@@ -148,8 +148,8 @@ If you downloaded a directory and `<target>` is a directory,
 you may override the directory with `-F|--rm-rf`.
 In no case will a directory be put into an existing directory.
 
-* `--preserve-git` and `--flat`:
-In `git-get`, `.git` is removed by default. You can override this with `--preserve-git`.
+* `-g|--preserve-git` and `--flat`:
+In `git-get`, `.git` is removed by default. You can override this with `-g|--preserve-git`.
 In `git-gets`, `.git` is kept by default. You can override this with `--flat`.
 
 ## Install

--- a/git-get
+++ b/git-get
@@ -26,7 +26,7 @@ usage()
 git-get [-v|--verbose|-q|--quiet]
     <url> | <user>/<repo> [<branch>|<sha1>]
     [-o <target> | --output=<target>] [-f|--force] [-F|--rm-rf]
-    [--preserve-git | [-t [--tag-file=VERSION]] [-- <path>]]
+    [-g|--preserve-git | [-t [--tag-file=VERSION]] [-- <path>]]
 EOF
 }
 
@@ -99,7 +99,7 @@ while [ $# -gt 0 ]; do
             OUTPUT="-"
             shift
             ;;
-        --preserve-git)
+        -g|--preserve-git)
             PRESERVE=YES
             shift
             ;;
@@ -135,11 +135,11 @@ while [ $# -gt 0 ]; do
     esac
 done
 if [ -n "$PRESERVE" ] && [ -n "$TAG" ]; then
-    echo "Error: Conflict: --preserve-git and --tag/--tag-file" >&2
+    echo "Error: Conflict: -g|--preserve-git and --tag/--tag-file" >&2
     exit 1
 fi
 if [ -n "$PRESERVE" ] && [ -n "$DIR" ]; then
-    echo "Error: Conflict: --preserve-git and -- <path>" >&2
+    echo "Error: Conflict: -g|--preserve-git and -- <path>" >&2
     exit 1
 fi
 


### PR DESCRIPTION
A convenient shorter command `-g` for `--preserve-git`. Did not use `-p` which can be misunderstood like `mkdir -p`.